### PR TITLE
Improve premium tools parallel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,50 +132,47 @@
             </div>
         </div>
         <!-- ...rest of your marketplace section... -->
-    </div>
-</section>
-
-                <!-- Advanced Tools Section -->
-                <div class="tools-section">
-                    <div class="section-header-small">
-                        <h3>⭐ Premium Tools</h3>
-                        <p>Advanced enterprise solutions with direct access and customization options</p>
+        <!-- Advanced Tools Section -->
+        <div class="tools-section premium-tools-section">
+            <div class="section-header-small">
+                <h3>⭐ Premium Tools</h3>
+                <p>Advanced enterprise solutions with direct access and customization options</p>
+            </div>
+            <div class="tools-grid parallel-tools">
+                <div class="tool-card premium">
+                    <div class="tool-header">
+                        <h4>UK Water–Energy Nexus: Resilience Gap Dashboard</h4>
+                        <div class="tool-badge premium">Premium</div>
                     </div>
-                    <div class="tools-grid">
-                        <div class="tool-card premium">
-                            <div class="tool-header">
-                                <h4>UK Water–Energy Nexus: Resilience Gap Dashboard</h4>
-                                <div class="tool-badge premium">Premium</div>
-                            </div>
-                            <p>Advanced resilience analysis for water-energy infrastructure with gap analysis and strategic recommendations</p>
-                            <ul class="tool-features">
-                                <li>Resilience gap analysis</li>
-                                <li>Infrastructure risk modeling</li>
-                                <li>Strategic recommendations</li>
-                                <li>Policy insights</li>
-                            </ul>
-                            <a href="https://topmate.io/jay_shah_btw/1715852" target="_blank" class="btn btn--outline btn--full-width">View Dashboard</a>
-                        </div>
+                    <p>Advanced resilience analysis for water-energy infrastructure with gap analysis and strategic recommendations</p>
+                    <ul class="tool-features">
+                        <li>Resilience gap analysis</li>
+                        <li>Infrastructure risk modeling</li>
+                        <li>Strategic recommendations</li>
+                        <li>Policy insights</li>
+                    </ul>
+                    <a href="https://topmate.io/jay_shah_btw/1715852" target="_blank" class="btn btn--outline btn--full-width">View Dashboard</a>
+                </div>
 
-                        <div class="tool-card premium">
-                            <div class="tool-header">
-                                <h4>GHG Emission Calculator Scope 1-2-3</h4>
-                                <div class="tool-badge premium">Premium</div>
-                            </div>
-                            <p>Comprehensive carbon footprint calculator covering all emission scopes with industry-specific calculations</p>
-                            <ul class="tool-features">
-                                <li>Multi-scope emission tracking</li>
-                                <li>Industry-specific calculations</li>
-                                <li>Reporting integration</li>
-                                <li>Custom EF support</li>
-                            </ul>
-                            <a href="https://topmate.io/jay_shah_btw/1703850" target="_blank" class="btn btn--outline btn--full-width">Access Tool</a>
-                            <small class="customization-note"><strong>Note:</strong> Can be customized as per relevant Emission Factors (EF) based on request</small>
-                        </div>
+                <div class="tool-card premium">
+                    <div class="tool-header">
+                        <h4>GHG Emission Calculator Scope 1-2-3</h4>
+                        <div class="tool-badge premium">Premium</div>
                     </div>
+                    <p>Comprehensive carbon footprint calculator covering all emission scopes with industry-specific calculations</p>
+                    <ul class="tool-features">
+                        <li>Multi-scope emission tracking</li>
+                        <li>Industry-specific calculations</li>
+                        <li>Reporting integration</li>
+                        <li>Custom EF support</li>
+                    </ul>
+                    <a href="https://topmate.io/jay_shah_btw/1703850" target="_blank" class="btn btn--outline btn--full-width">Access Tool</a>
+                    <small class="customization-note"><strong>Note:</strong> Can be customized as per relevant Emission Factors (EF) based on request</small>
                 </div>
             </div>
-        </section>
+        </div>
+    </div>
+</section>
 
         <!-- Services Section -->
         <section id="services" class="services">

--- a/style.css
+++ b/style.css
@@ -970,10 +970,14 @@ select.form-control {
 }
 
 .tools-grid.parallel-tools {
-    display: flex;
+    display: grid;
     gap: 2rem;
-    flex-wrap: wrap;
-    justify-content: center;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: stretch;
+}
+
+.premium-tools-section .tools-grid.parallel-tools {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .tool-card {
@@ -984,10 +988,21 @@ select.form-control {
     flex: 1 1 320px;
     min-width: 280px;
     max-width: 350px;
+    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     margin-bottom: 2rem;
+}
+
+.premium-tools-section .tool-card {
+    max-width: none;
+}
+
+@media (min-width: 1024px) {
+    .premium-tools-section .tools-grid.parallel-tools {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 .tool-card:hover {


### PR DESCRIPTION
## Summary
- keep the premium marketplace dashboards inside the marketplace section and wrap them in a dedicated premium layout container
- adjust the parallel tools grid styling to use CSS grid and force the premium cards to stretch side by side on wide screens

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68db9cf7e1688328a5de2028bb4b41d2